### PR TITLE
自動ビルドを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,14 +38,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pantry-
 
-    - name: Cache .stack/programs
-      id: cache-programs
+    - name: Cache .stack/**/ghc
+      id: cache-ghc
       uses: actions/cache@v1
       with:
-        path: ~/.stack-temp/programs
-        key: ${{ runner.os }}-programs-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
+        path: ~/.stack-temp/ghc
+        key: ${{ runner.os }}-ghc-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
         restore-keys: |
-          ${{ runner.os }}-programs-
+          ${{ runner.os }}-ghc-
 
     - name: Cache .stack-work
       id: cache-work
@@ -64,13 +64,13 @@ jobs:
           pantry
         target_dir: ~/.stack
 
-    - name: Move .stack/programs to temp
+    - name: Move .stack/**/ghc to temp
       uses: matsubara0507/actions/move-files@master
       with:
-        source_dir: ~/.stack-temp/programs
+        source_dir: ~/.stack-temp/ghc
         source_files: |
-          programs
-        target_dir: ~/.stack
+          ghc-${{ matrix.ghc }}
+        target_dir: ~/.stack/programs/programs/x86_64-linux
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,29 @@ jobs:
         fetch-depth: 1
 
     - name: Cache .stack
+      id: cache-stack
       uses: actions/cache@v1
       with:
         path: ~/.stack
         key: ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}
         restore-keys: |
           ${{ runner.os }}-stack-
+
+    - name: Cache .stack/pantry
+      id: cache-pantry
+      uses: actions/cache@v1
+      with:
+        path: ~/.stack-temp
+        key: ${{ runner.os }}-pantry-${{ hashFiles('**/stack.yaml.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pantry-
+
+    - uses: matsubara0507/actions/move-files@master
+      with:
+        source_dir: ~/.stack-temp
+        source_files: |
+          pantry
+        target_dir: ~/.stack
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -48,5 +65,3 @@ jobs:
     - name: Remove .stack/programs for cache
       run: |
         rm -rfd ~/.stack/programs
-        rm -rfd ~/.stack/hackage
-        rm -rfd ~/.stack/snapshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,10 +85,10 @@ jobs:
     - uses: mstksg/setup-stack@v1
 
     - name: Install dependencies
-      run: stack --docker build --only-dependencies
+      run: stack --system-ghc build --only-dependencies
 
     - name: Build binary
-      run: stack --docker install --local-bin-path=./bin
+      run: stack --system-ghc install --local-bin-path=./bin
 
     - name: Display after .stack size
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         ghc: ["8.6.5"]
         cabal: ["3.0"]
-        cache-version: ["v1"]
+        cache-version: ["v2"]
 
     steps:
     - uses: actions/checkout@v1
@@ -70,7 +70,7 @@ jobs:
         source_dir: ~/.stack-temp/ghc
         source_files: |
           ghc-${{ matrix.ghc }}
-        target_dir: ~/.stack/programs/programs/x86_64-linux
+        target_dir: ~/.stack/programs/x86_64-linux
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  pull_request: null
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 1
+
+    - name: Cache .stack
+      uses: actions/cache@v1
+      with:
+        path: ~/.stack
+        key: ${{ matrix.ghc }}-stack-${{ hashFiles('**/stack.yaml.lock') }}
+        restore-keys: |
+          ${{ matrix.ghc }}-stack-
+
+    - uses: actions/setup-haskell@v1
+      name: Setup Haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - uses: mstksg/setup-stack@v1
+
+    - name: Install dependencies
+      run: stack --docker --system-ghc build --only-dependencies
+
+    - name: Build binary
+      run: stack --docker --system-ghc install --local-bin-path=./bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Build binary
       run: stack --docker install --local-bin-path=./bin
 
-    - name: Debug
+    - name: Display .stack size
       run: |
         du -sh ~/.stack/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,14 +38,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pantry-
 
-    - name: Cache .stack/**/ghc
-      id: cache-ghc
-      uses: actions/cache@v1
-      with:
-        path: ~/.stack-temp/ghc
-        key: ${{ runner.os }}-ghc-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
-        restore-keys: |
-          ${{ runner.os }}-ghc-
+    # - name: Cache .stack/**/ghc
+    #   id: cache-ghc
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.stack-temp/ghc
+    #     key: ${{ runner.os }}-ghc-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-ghc-
 
     # - name: Cache .stack-work
     #   id: cache-work
@@ -64,13 +64,13 @@ jobs:
           pantry
         target_dir: ~/.stack
 
-    - name: Move .stack/**/ghc to temp
-      uses: matsubara0507/actions/move-files@master
-      with:
-        source_dir: ~/.stack-temp/ghc
-        source_files: |
-          ghc-${{ matrix.ghc }}
-        target_dir: ~/.stack/programs/x86_64-linux
+    # - name: Move .stack/**/ghc to temp
+    #   uses: matsubara0507/actions/move-files@master
+    #   with:
+    #     source_dir: ~/.stack-temp/ghc
+    #     source_files: |
+    #       ghc-${{ matrix.ghc }}
+    #     target_dir: ~/.stack/programs/x86_64-linux
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -91,3 +91,6 @@ jobs:
         du -sh ~/.stack/*
         du -sh ~/.stack/programs/x86_64-linux/*
         du -sh .stack-work/*
+
+    - name: Remove GHC
+      run: rm -rfd ~/.stack/programs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pantry-
 
+    - name: Cache .stack-work
+      id: cache-work
+      uses: actions/cache@v1
+      with:
+        path: .stack-work
+        key: ${{ runner.os }}-local-stack-${{ hashFiles('**/stack.yaml.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-local-stack
+
     - uses: matsubara0507/actions/move-files@master
       with:
         source_dir: ~/.stack-temp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,6 @@ jobs:
     - name: Display before .stack size
       run: |
         du -sh ~/.stack/*
-        du -sh ~/.stack/programs/*
         du -sh .stack-work/*
 
     - uses: actions/setup-haskell@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         fetch-depth: 1
 
     - name: Cache .stack
-      uses: actions/cache@master
+      uses: actions/cache@v1
       with:
         path: ~/.stack
         key: ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,6 @@ jobs:
     - name: Display .stack size
       run: |
         du -sh ~/.stack/*
-        du -sh ~/.stack/programs/x86_64-linux/*
         du -sh .stack-work/*
 
     # - name: Remove GHC

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,23 @@ jobs:
     - name: Build binary
       run: stack --system-ghc install --local-bin-path=./bin
 
+    - name: Build Docker Image
+      run: docker build -t octbook . --build-arg local_bin_path=./bin
+
+    - name: Push Docker Image
+      if: github.ref == 'refs/heads/master'
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u matsubara0507 --password-stdin
+        docker tag octbook docker.pkg.github.com/matsubara0507/octbook/cli
+        docker push docker.pkg.github.com/matsubara0507/octbook/cli:latest
+
+    - name: Push Docker Image (tag)
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u matsubara0507 --password-stdin
+        docker tag octbook docker.pkg.github.com/matsubara0507/octbook/cli:${GITHUB_REF#refs/tags/}
+        docker push docker.pkg.github.com/matsubara0507/octbook/cli:${GITHUB_REF#refs/tags/}
+
     - name: Display .stack size
       run: |
         du -sh ~/.stack/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,8 @@ jobs:
     - name: Display before .stack size
       run: |
         du -sh ~/.stack/*
-        du -sh .stack-work
+        du -sh ~/.stack/programs/*
+        du -sh .stack-work/*
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -85,12 +86,13 @@ jobs:
     - uses: mstksg/setup-stack@v1
 
     - name: Install dependencies
-      run: stack --system-ghc build --only-dependencies
+      run: stack build --only-dependencies
 
     - name: Build binary
-      run: stack --system-ghc install --local-bin-path=./bin
+      run: stack install --local-bin-path=./bin
 
     - name: Display after .stack size
       run: |
         du -sh ~/.stack/*
-        du -sh .stack-work
+        du -sh ~/.stack/programs/*
+        du -sh .stack-work/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,12 @@ jobs:
       run: stack --docker install --local-bin-path=./bin
 
     - name: Debug
-      run: du -sh ~/.stack/*
+      run: |
+        du -sh ~/.stack/*
+        ls -la ~/.stack/programs
+        ls -la ~/.stack/hackage
 
     - name: Remove .stack/programs for cache
-      run: rm -rfd ~/.stack/programs
+      run: |
+        rm -rfd ~/.stack/programs
+        rm -rfd ~/.stack/hackage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,4 @@ jobs:
       run: |
         rm -rfd ~/.stack/programs
         rm -rfd ~/.stack/hackage
+        rm -rfd ~/.stack/snapshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
     - name: Display .stack size
       run: |
         du -sh ~/.stack/*
+        du -sh .stack-work
 
     - name: Remove .stack/programs for cache
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,14 +47,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-ghc-
 
-    - name: Cache .stack-work
-      id: cache-work
-      uses: actions/cache@v1
-      with:
-        path: .stack-work
-        key: ${{ runner.os }}-local-stack-${{ hashFiles('**/stack.yaml.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-local-stack
+    # - name: Cache .stack-work
+    #   id: cache-work
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: .stack-work
+    #     key: ${{ runner.os }}-local-stack-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-local-stack
 
     - name: Move .stack/pantry to temp
       uses: matsubara0507/actions/move-files@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,17 @@ jobs:
         cabal: ["3.0"]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
       with:
         fetch-depth: 1
 
-    - name: Cache .stack pantry
-      uses: actions/cache@v1
+    - name: Cache .stack
+      uses: actions/cache@master
       with:
-        path: ~/.stack/pantry
-        key: ${{ runner.os }}-stack-pantry-${{ hashFiles('**/stack.yaml.lock') }}
+        path: ~/.stack
+        key: ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}
         restore-keys: |
-          ${{ runner.os }}-stack-pantry-
+          ${{ runner.os }}-stack-
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -43,3 +43,6 @@ jobs:
 
     - name: Debug
       run: du -sh ~/.stack/*
+
+    - name: Remove .stack/programs for cache
+      run: rm -rfd ~/.stack/programs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,24 +15,21 @@ jobs:
       with:
         fetch-depth: 1
 
-    - name: Cache .stack
+    - name: Cache .stack pantry
       uses: actions/cache@v1
       with:
-        path: ~/.stack
-        key: ${{ matrix.ghc }}-stack-${{ hashFiles('**/stack.yaml.lock') }}
+        path: ~/.stack/pantry
+        key: ${{ runner.os }}-stack-pantry-${{ hashFiles('**/stack.yaml.lock') }}
         restore-keys: |
-          ${{ matrix.ghc }}-stack-
-
-    - uses: actions/setup-haskell@v1
-      name: Setup Haskell
-      with:
-        ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
+          ${{ runner.os }}-stack-pantry-
 
     - uses: mstksg/setup-stack@v1
 
     - name: Install dependencies
-      run: stack --docker --system-ghc build --only-dependencies
+      run: stack --docker build --only-dependencies
 
     - name: Build binary
-      run: stack --docker --system-ghc install --local-bin-path=./bin
+      run: stack --docker install --local-bin-path=./bin
+
+    - name: Debug
+      run: du -sh ~/.stack/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,24 +38,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pantry-
 
-    # - name: Cache .stack/**/ghc
-    #   id: cache-ghc
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: ~/.stack-temp/ghc
-    #     key: ${{ runner.os }}-ghc-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-ghc-
-
-    # - name: Cache .stack-work
-    #   id: cache-work
-    #   uses: actions/cache@v1
-    #   with:
-    #     path: .stack-work
-    #     key: ${{ runner.os }}-local-stack-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-local-stack
-
     - name: Move .stack/pantry to temp
       uses: matsubara0507/actions/move-files@master
       with:
@@ -63,14 +45,6 @@ jobs:
         source_files: |
           pantry
         target_dir: ~/.stack
-
-    # - name: Move .stack/**/ghc to temp
-    #   uses: matsubara0507/actions/move-files@master
-    #   with:
-    #     source_dir: ~/.stack-temp/ghc
-    #     source_files: |
-    #       ghc-${{ matrix.ghc }}
-    #     target_dir: ~/.stack/programs/x86_64-linux
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -90,6 +64,3 @@ jobs:
       run: |
         du -sh ~/.stack/*
         du -sh .stack-work/*
-
-    # - name: Remove GHC
-    #   run: rm -rfd ~/.stack/programs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         ghc: ["8.6.5"]
         cabal: ["3.0"]
+        cache-version: ["v1"]
 
     steps:
     - uses: actions/checkout@v1
@@ -24,7 +25,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}
+        key: ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
         restore-keys: |
           ${{ runner.os }}-stack-
 
@@ -33,7 +34,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.stack-temp/pantry
-        key: ${{ runner.os }}-pantry-${{ hashFiles('**/stack.yaml.lock') }}
+        key: ${{ runner.os }}-pantry-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
         restore-keys: |
           ${{ runner.os }}-pantry-
 
@@ -42,7 +43,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.stack-temp/programs
-        key: ${{ runner.os }}-programs-${{ hashFiles('**/stack.yaml.lock') }}
+        key: ${{ runner.os }}-programs-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
         restore-keys: |
           ${{ runner.os }}-programs-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,19 @@ jobs:
       id: cache-pantry
       uses: actions/cache@v1
       with:
-        path: ~/.stack-temp
+        path: ~/.stack-temp/pantry
         key: ${{ runner.os }}-pantry-${{ hashFiles('**/stack.yaml.lock') }}
         restore-keys: |
           ${{ runner.os }}-pantry-
+
+    - name: Cache .stack/programs
+      id: cache-programs
+      uses: actions/cache@v1
+      with:
+        path: ~/.stack-temp/programs
+        key: ${{ runner.os }}-programs-${{ hashFiles('**/stack.yaml.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-programs-
 
     - name: Cache .stack-work
       id: cache-work
@@ -46,12 +55,26 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-local-stack
 
-    - uses: matsubara0507/actions/move-files@master
+    - name: Move .stack/pantry to temp
+      uses: matsubara0507/actions/move-files@master
       with:
-        source_dir: ~/.stack-temp
+        source_dir: ~/.stack-temp/pantry
         source_files: |
           pantry
         target_dir: ~/.stack
+
+    - name: Move .stack/programs to temp
+      uses: matsubara0507/actions/move-files@master
+      with:
+        source_dir: ~/.stack-temp/programs
+        source_files: |
+          programs
+        target_dir: ~/.stack
+
+    - name: Display before .stack size
+      run: |
+        du -sh ~/.stack/*
+        du -sh .stack-work
 
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
@@ -67,11 +90,7 @@ jobs:
     - name: Build binary
       run: stack --docker install --local-bin-path=./bin
 
-    - name: Display .stack size
+    - name: Display after .stack size
       run: |
         du -sh ~/.stack/*
         du -sh .stack-work
-
-    - name: Remove .stack/programs for cache
-      run: |
-        rm -rfd ~/.stack/programs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         ghc: ["8.6.5"]
         cabal: ["3.0"]
-        cache-version: ["v2"]
+        cache-version: ["v3"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         ghc: ["8.6.5"]
         cabal: ["3.0"]
-        cache-version: ["v3"]
+        cache-version: ["v4"]
 
     steps:
     - uses: actions/checkout@v1
@@ -81,10 +81,10 @@ jobs:
     - uses: mstksg/setup-stack@v1
 
     - name: Install dependencies
-      run: stack build --only-dependencies
+      run: stack --system-ghc build --only-dependencies
 
     - name: Build binary
-      run: stack install --local-bin-path=./bin
+      run: stack --system-ghc install --local-bin-path=./bin
 
     - name: Display .stack size
       run: |
@@ -92,5 +92,5 @@ jobs:
         du -sh ~/.stack/programs/x86_64-linux/*
         du -sh .stack-work/*
 
-    - name: Remove GHC
-      run: rm -rfd ~/.stack/programs
+    # - name: Remove GHC
+    #   run: rm -rfd ~/.stack/programs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,14 +71,6 @@ jobs:
           programs
         target_dir: ~/.stack
 
-    - name: Display before .stack size
-      run: |
-        mkdir -p ~/.stack/programs/x86_64-linux
-        mkdir -p .stack-work
-        du -sh ~/.stack/*
-        du -sh ~/.stack/programs/x86_64-linux/*
-        du -sh .stack-work/*
-
     - uses: actions/setup-haskell@v1
       name: Setup Haskell
       with:
@@ -93,7 +85,7 @@ jobs:
     - name: Build binary
       run: stack install --local-bin-path=./bin
 
-    - name: Display after .stack size
+    - name: Display .stack size
       run: |
         du -sh ~/.stack/*
         du -sh ~/.stack/programs/x86_64-linux/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        ghc: ["8.6.5"]
+        cabal: ["3.0"]
 
     steps:
     - uses: actions/checkout@master
@@ -22,6 +26,12 @@ jobs:
         key: ${{ runner.os }}-stack-pantry-${{ hashFiles('**/stack.yaml.lock') }}
         restore-keys: |
           ${{ runner.os }}-stack-pantry-
+
+    - uses: actions/setup-haskell@v1
+      name: Setup Haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
 
     - uses: mstksg/setup-stack@v1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,10 @@ jobs:
 
     - name: Display before .stack size
       run: |
+        mkdir -p ~/.stack/programs/x86_64-linux
+        mkdir -p .stack-work
         du -sh ~/.stack/*
+        du -sh ~/.stack/programs/x86_64-linux/*
         du -sh .stack-work/*
 
     - uses: actions/setup-haskell@v1
@@ -93,5 +96,5 @@ jobs:
     - name: Display after .stack size
       run: |
         du -sh ~/.stack/*
-        du -sh ~/.stack/programs/*
+        du -sh ~/.stack/programs/x86_64-linux/*
         du -sh .stack-work/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,6 @@ jobs:
     - name: Debug
       run: |
         du -sh ~/.stack/*
-        ls -la ~/.stack/programs
-        ls -la ~/.stack/hackage
 
     - name: Remove .stack/programs for cache
       run: |

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ $ octbook --kick=team --users=matsubara0507 --teams=Sample path/to/.octbook.yaml
 
 ### Docker
 
-use [matsubara0507/octbook](https://hub.docker.com/r/matsubara0507/octbook)
+use [matsubara0507/octbook](https://github.com/matsubara0507/octbook/packages)
 
 ```
-$ docker run -v `pwd`:/work matsubara0507/octbook --help
+$ docker run -v `pwd`:/work docker.pkg.github.com/matsubara0507/octbook/cli --help
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # octbook
 
+![](https://github.com/matsubara0507/octbook/workflows/Build/badge.svg)
+
 Invite GitHub Organizations or GitHub Organizations Team by config YAML:
 
 ```yaml


### PR DESCRIPTION
とりあえず GitHub Actions 試すけど、キャッシュがあれだとやめるけど。

色々試してわかったこと:

- `~/.stack` で重いのは `~/.stack/pantry` と `~/.stack/programs`
    - 全体で4G強でこれが圧縮されて800M強ぐらい
- `~/.stack/programs` は system-ghc を使うことで不要（これで -1.8G)
- 微妙に400Mに届かないので https://github.com/matsubara0507/actions/tree/master/move-files を使って分割キャッシュ(pantry だけ)
- `.stack-work` は無くて良い
- キャッシュは key が同じだと save しない使用（これに結構つまずいた)
    - 現状は手動 clean することもできないので cache-version を足した笑